### PR TITLE
modify grep tool to include line number

### DIFF
--- a/apps/spellbound/src/tools/grep/grepToolImpl.ts
+++ b/apps/spellbound/src/tools/grep/grepToolImpl.ts
@@ -8,7 +8,7 @@ type GrepResult = {
 }
 
 export async function grepToolImpl({ regex, path }: GrepToolInterface) {
-  const result = await runGitCommand(`grep --exclude-standard --no-index -e '${regex}' -- ${path || '.'}`)
+  const result = await runGitCommand(`grep -n --exclude-standard --no-index -e '${regex}' -- ${path || '.'}`)
   if (result.startsWith('ERROR')) {
     return "No files found."
   }


### PR DESCRIPTION
The AI qualitatively gives better `diff` results when `grep` includes the line number that a particular piece of text appears. This modifies `grep` to use the `-n` flag, which includes line number.